### PR TITLE
Fix inference for fix(::Type, ...)

### DIFF
--- a/src/Curry.jl
+++ b/src/Curry.jl
@@ -48,6 +48,8 @@ struct Fix{F, A, K} <: Function
     k::K
 end
 
+Fix(::Type{T}, a, k) where {T} = Fix{Type{T}, typeof(a), typeof(k)}(T, a, k)
+
 function (c::Fix)(args...; kw...)
     c.f(interleave(c.a, args)...; c.k..., kw...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,10 @@ end
 @testset "fix(::Type, ...)" begin
     f = @inferred fix(CartesianIndex, nothing, Some(1))
     @test @inferred(f(2)) === CartesianIndex(2, 1)
+
+    modulo(x; by) = mod(x, by)
+    g = @inferred fix(modulo, nothing, by = UInt8)
+    @test_broken @inferred(g(271)) === 0x0f
 end
 
 @testset "Fix.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,11 @@ using Test
     @inferred a1(1.0)
 end
 
+@testset "fix(::Type, ...)" begin
+    f = @inferred fix(CartesianIndex, nothing, Some(1))
+    @test @inferred(f(2)) === CartesianIndex(2, 1)
+end
+
 @testset "Fix.jl" begin
 
     #=


### PR DESCRIPTION
This PR fixes inference for, e.g., `fix(CartesianIndex, nothing, Some(1))(2)`.