### PR TITLE
example with `@fix reduce(vcat, ...)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,9 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
-      - uses: julia-actions/julia-uploadcoveralls@latest
+      - uses: julia-actions/julia-uploadcodecov@latest
         env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,7 +84,7 @@ end
     @test_broken @inferred(g(271)) === 0x0f
 end
 
-@testset "Fix.jl" begin
+@testset "`Rational` as lazy `/``" begin
 
     #=
     example replacement of Rational
@@ -108,7 +108,9 @@ end
     @test half() == 0.5
 
     @test typeof(FixArgs.@fix union([1], [2])) == FixArgs.@FixT union(::Vector{Int64}, ::Vector{Int64})
+end
 
+@testset "lazy `union`" begin
     #=
     example deferring `Set` operations
     =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -162,6 +162,39 @@ end
     @test b(", you, ") == "hey, you, there"
 end
 
+@testset "lazy `reduce(vcat, ...)`" begin
+    # A watered-down version of `LazyArrays.Vcat`:
+    # https://github.com/JuliaArrays/LazyArrays.jl/blob/dff5924cd8b52c62a34cce16372381bb8a9e35cb/src/lazyconcat.jl#L11
+
+    # TODO generalie to `AbstractVector`
+    # T_reduce_vcat_vector{T} = (@FixT reduce(::typeof(vcat), ::AbstractVector{<:AbstractVector{T}}))
+    T_reduce_vcat_vector{T} = (@FixT reduce(::typeof(vcat), ::Vector{Vector{T}}))
+
+    _vec_of_vec(reduce_vcat) = something(reduce_vcat.args[2])
+
+    function Base.length(reduce_vcat::T_reduce_vcat_vector{T}) where {T}
+        sum(length.(_vec_of_vec(reduce_vcat)))
+    end
+
+    function Base.getindex(reduce_vcat::T_reduce_vcat_vector{T}, i::Integer) where {T}
+        # TODO validate that all `Vector`s start with index `1`
+        vec_of_vec = _vec_of_vec(reduce_vcat)
+        lengths = length.(vec_of_vec)
+        cum_lengths = cumsum(lengths)
+        i_outer = searchsortedfirst(cum_lengths, i)
+        i_inner = i - (i_outer > 1 ? cum_lengths[i_outer-1] : 0)
+        return vec_of_vec[i_outer][i_inner]
+    end
+
+    ref = reduce(vcat, [[:a, :b, :c], [:d, :e]])
+    laz = @fix reduce(vcat, [[:a, :b, :c], [:d, :e]])
+
+    @test length(ref) == length(laz)
+    for i = 1:length(ref)
+        @test ref[i] == laz[i]
+    end
+end
+
 using Documenter: DocMeta, doctest
 
 # implicit `using FixArgs` in every doctest


### PR DESCRIPTION
As far as I can tell, this is in the same spirit of https://github.com/JuliaArrays/LazyArrays.jl/blob/dff5924cd8b52c62a34cce16372381bb8a9e35cb/src/lazyconcat.jl#L11

The big downside is that it's not itself `<:AbstractArray` Something like https://github.com/schlichtanders/ProxyInterfaces.jl/blob/66484253f0e181651fcfe393c9b42cfc70ac77df/src/array.jl could be used to quickly wrap the `::Fix`.

The point as I see it is that the type `LazyArrays.Vcat` can in principle be constructed from existing components `Fix`, `reduce`, `vcat`, and possibly a wrapper type to give it the property `<:AbstractArray`. 