### PR TITLE
Use `Val` for static arguments

### DIFF
--- a/src/FixArgs.jl
+++ b/src/FixArgs.jl
@@ -56,7 +56,7 @@ _interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
 
 # recursively evaluate unescaped `Fix`
 _interleave(firstbind::Fix, tailbind::Tuple, args::Tuple) where T = (
-    firstbind(first(args)...), interleave(tailbind, tail(args))...)
+    firstbind((first(args)::Tuple)...), interleave(tailbind, tail(args))...)
 
 """
     `fix(f, a, b)`

--- a/src/FixArgs.jl
+++ b/src/FixArgs.jl
@@ -45,14 +45,14 @@ interleave(bind::Tuple{}, args::Tuple) = error("more args than positions")
 
 # `nothing` indicates a position to be bound
 _interleave(firstbind::Nothing, tailbind::Tuple, args::Tuple) = (
-  first(args), interleave(tailbind, tail(args))...)
+    first(args), interleave(tailbind, tail(args))...)
 
 # allow escaping of e.g. `nothing`
 _interleave(firstbind::Some{T}, tailbind::Tuple, args::Tuple) where T = (
-  something(firstbind), interleave(tailbind, args)...)
+    something(firstbind), interleave(tailbind, args)...)
 
 _interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
-  firstbind, interleave(tailbind, args)...)
+    firstbind, interleave(tailbind, args)...)
 
 # recursively evaluate unescaped `Fix`
 _interleave(firstbind::Fix, tailbind::Tuple, args::Tuple) where T = (

--- a/src/FixArgs.jl
+++ b/src/FixArgs.jl
@@ -4,6 +4,21 @@ using Base: tail
 export Fix, @fix, fix, @FixT
 
 """
+Represent a function call, with partially bound arguments.
+"""
+struct Fix{F, A, K} <: Function
+    f::F
+    args::A
+    kw::K
+end
+
+Fix(::Type{T}, a, k) where {T} = Fix{Type{T}, typeof(a), typeof(k)}(T, a, k)
+
+function (c::Fix)(args...; kw...)
+    c.f(interleave(c.args, args)...; c.kw..., kw...)
+end
+
+"""
 Return a `Tuple` that interleaves `args` into the `nothing` slots of `slots`.
 
 ```jldoctest
@@ -38,21 +53,6 @@ _interleave(firstbind::Some{T}, tailbind::Tuple, args::Tuple) where T = (
 
 _interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
   firstbind, interleave(tailbind, args)...)
-
-"""
-Represent a function call, with partially bound arguments.
-"""
-struct Fix{F, A, K} <: Function
-    f::F
-    args::A
-    kw::K
-end
-
-Fix(::Type{T}, a, k) where {T} = Fix{Type{T}, typeof(a), typeof(k)}(T, a, k)
-
-function (c::Fix)(args...; kw...)
-    c.f(interleave(c.args, args)...; c.kw..., kw...)
-end
 
 """
     `fix(f, a, b)`

--- a/src/FixArgs.jl
+++ b/src/FixArgs.jl
@@ -114,15 +114,19 @@ macro fix(call)
     esc(ret)
 end
 
+SomeUnlessFix(x) = Some(x)          # if macro invocation contains a "bare" argument, wrap it
+SomeUnlessFix(x::Fix) = x           # unless it is `Fix`
+SomeUnlessFix(x::Some{<:Fix}) = x   # but if `Some` is used to escape this behavior, then do not wrap it again
+
 function escape_arg(ex)
     if Meta.isexpr(ex, :kw)
         ex
     elseif Meta.isexpr(ex, Symbol("..."))
-        :(map(Some, $(ex.args[1]))...)
+        :(map(Some, $(ex.args[1]))...)      # TODO also `SomeUnlessFix` here?
     elseif ex == :_
         nothing
     else
-        Expr(:call, Some, ex)
+        Expr(:call, SomeUnlessFix, ex)
     end
 end
 

--- a/src/FixArgs.jl
+++ b/src/FixArgs.jl
@@ -54,6 +54,10 @@ _interleave(firstbind::Some{T}, tailbind::Tuple, args::Tuple) where T = (
 _interleave(firstbind::T, tailbind::Tuple, args::Tuple) where T = (
   firstbind, interleave(tailbind, args)...)
 
+# recursively evaluate unescaped `Fix`
+_interleave(firstbind::Fix, tailbind::Tuple, args::Tuple) where T = (
+    firstbind(first(args)...), interleave(tailbind, tail(args))...)
+
 """
     `fix(f, a, b)`
     `fix(f, args...; kw...)`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,24 @@ end
     end
 end
 
+@testset "nested fix" begin
+    nested = (Fix(/, ((Fix(+, (nothing, nothing), NamedTuple())), nothing), NamedTuple()))
+    @test nested((1,2), 3) === 1.0
+    @test (@inferred nested((1,2), 3)) === 1.0
+
+    @test_throws Exception nested()
+    @test_throws Exception nested(1)
+    @test_throws Exception nested(1, 2)
+    @test_throws Exception nested(1, 2, 3)
+    @test_throws Exception nested((1, 2, 4), 3)
+    @test_throws Exception nested((1, 2), 3, 5)
+    @test_throws Exception nested((1,), 3)
+    @test_throws Exception nested((), 3)
+
+    not_nested = (Fix(/, (Some(Fix(+, (nothing, nothing), NamedTuple())), nothing), NamedTuple()))
+    @test_throws MethodError not_nested(1)
+end
+
 using Documenter: DocMeta, doctest
 
 # implicit `using FixArgs` in every doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,7 +227,7 @@ end
     end
 
     @fix string("a call ", _)
-    @fix tuple("a call ", _)
+    @fix tuple(:a_call, _)
 end
 
 using Documenter: DocMeta, doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,8 +226,15 @@ end
         @test_throws Exception eval(:(@fix (;a=:not_a_call, b=_)))
     end
 
-    @fix string("a call ", _)
-    @fix tuple(:a_call, _)
+    fs = @fix string("a call ", _)
+    ft = @fix tuple(:a_call, _)
+    fnt = @fix NamedTuple{(:a, :b)}(@fix tuple(:a_call, _))
+
+    @test fs(4) == "a call 4"
+    @test ft(4) == (:a_call, 4)
+    @test fnt((4,)) ==  NamedTuple{(:a, :b)}((:a_call, 4))
+    # TODO since `4` can be splat (`Number` defines `iterate`), this does not error.
+    @test fnt(4) ==  NamedTuple{(:a, :b)}((:a_call, 4))
 end
 
 using Documenter: DocMeta, doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,9 @@ end
 
     not_nested = (Fix(/, (Some(Fix(+, (nothing, nothing), NamedTuple())), nothing), NamedTuple()))
     @test_throws MethodError not_nested(1)
+
+    @test (@fix (@fix _ + _) / _) === nested
+    @test (@fix Some(@fix _ + _) / _) === not_nested
 end
 
 using Documenter: DocMeta, doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,7 +197,7 @@ end
     end
 end
 
-@testset "nested fix" begin
+@testset "nested fix two arguments" begin
     nested = (Fix(/, ((Fix(+, (nothing, nothing), NamedTuple())), nothing), NamedTuple()))
     @test nested((1,2), 3) === 1.0
     @test (@inferred nested((1,2), 3)) === 1.0
@@ -218,6 +218,12 @@ end
     @test (@fix Some(@fix _ + _) / _) === not_nested
 end
 
+@testset "nested fix one arguments" begin
+    nested = (@fix (@fix _ + 1) / _)
+    @test_throws Exception nested(1, 2)
+    @test nested((1, ), 2) === 1.0
+end
+
 @testset "calls and not calls" begin
     # These errors are thrown at macro expansion time.
     @test_throws Exception eval(:(@fix "not a call $(_)"))
@@ -233,8 +239,7 @@ end
     @test fs(4) == "a call 4"
     @test ft(4) == (:a_call, 4)
     @test fnt((4,)) ==  NamedTuple{(:a, :b)}((:a_call, 4))
-    # TODO since `4` can be splat (`Number` defines `iterate`), this does not error.
-    @test fnt(4) ==  NamedTuple{(:a, :b)}((:a_call, 4))
+    @test_throws Exception fnt(4)
 end
 
 using Documenter: DocMeta, doctest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,6 +224,12 @@ end
     @test nested((1, ), 2) === 1.0
 end
 
+@testset "nested fix zero arguments" begin
+    nested = (@fix (@fix 1 + 1) / _)
+    @test_throws Exception nested(2)
+    @test nested((), 2) === 1.0
+end
+
 @testset "calls and not calls" begin
     # These errors are thrown at macro expansion time.
     @test_throws Exception eval(:(@fix "not a call $(_)"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,16 +47,6 @@ using Test
 
     @test_throws Exception @fix(_ + _)(1, 2, 3)
     @test_throws Exception @fix(_ + _)(1)
-
-    # These errors are thrown at macro expansion time.
-    @test_throws Exception eval(:(@fix "not a call $(_)"))
-    @test_throws Exception eval(:(@fix (:not_a_call, _)))
-    if VERSION ≥ v"1.5"
-        @test_throws Exception eval(:(@fix (;a=:not_a_call, b=_)))
-    end
-
-    @fix string("a call ", _)
-    @fix tuple("a call ", _)
 end
 
 @testset "@fix object structure" begin
@@ -226,6 +216,18 @@ end
 
     @test (@fix (@fix _ + _) / _) === nested
     @test (@fix Some(@fix _ + _) / _) === not_nested
+end
+
+@testset "calls and not calls" begin
+    # These errors are thrown at macro expansion time.
+    @test_throws Exception eval(:(@fix "not a call $(_)"))
+    @test_throws Exception eval(:(@fix (:not_a_call, _)))
+    if VERSION ≥ v"1.5"
+        @test_throws Exception eval(:(@fix (;a=:not_a_call, b=_)))
+    end
+
+    @fix string("a call ", _)
+    @fix tuple("a call ", _)
 end
 
 using Documenter: DocMeta, doctest


### PR DESCRIPTION
Does not inherently depend on https://github.com/goretkin/FixArgs.jl/pull/17 , but the "complex" test depends on both features. 